### PR TITLE
Support css "image-set" function for retina images

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ class WebImagesCSS {
 			columnIndex,
 			`
 				.${modernExtension} ${selectors.join('')} {
-					${rule.property}: ${rule.value.replace(imageExtension, modernExtension)}
+					${rule.property}: ${rule.value.replaceAll(imageExtension, modernExtension)}
 				}
 			`.replaceAll('\n', '')
 			)


### PR DESCRIPTION
Hi, I was stuck on a problem and found out how to fix it. 

If you parse your css code through your plugin, and if you have an image-set function with images of various resolutions, it won't change the image format for each image.

Before:
``` CSS
.test {
	background: image-set(
		url("../images/image-1.jpg") 1x,
		url("../images/image-1@2x.jpg") 2x,
		url("../images/image-1@3x.jpg") 3x
	));
}
```

After:
``` CSS
.webp .test {
	background: image-set(
		url("../images/image-1.webp") 1x,
		url("../images/image-1@2x.jpg") 2x,
		url("../images/image-1@3x.jpg") 3x
	));
}

.avif .test {
	background: image-set(
		url("../images/image-1.avif") 1x,
		url("../images/image-1@2x.jpg") 2x,
		url("../images/image-1@3x.jpg") 3x
	));
}
```

So, i found out that if you change the replace method to replaceAll it will work correct.

![AvifCss](https://github.com/user-attachments/assets/b876999e-2d80-45dc-b787-fbdb59de3bad)

Before:
``` CSS
.test {
	background: image-set(
		url("../images/image-1.jpg") 1x,
		url("../images/image-1@2x.jpg") 2x,
		url("../images/image-1@3x.jpg") 3x
	));
}
```

After:
``` CSS
.webp .test {
	background: image-set(
		url("../images/image-1.webp") 1x,
		url("../images/image-1@2x.webp") 2x,
		url("../images/image-1@3x.webp") 3x
	));
}

.avif .test {
	background: image-set(
		url("../images/image-1.avif") 1x,
		url("../images/image-1@2x.avif") 2x,
		url("../images/image-1@3x.avif") 3x
	));
}
```